### PR TITLE
Fix broken assignment in patch method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ class Service {
 
       Object.keys(data).forEach(function(key) {
         if (typeof instance[key] !== 'undefined') {
-          instance[key] == data[key];
+          instance[key] = data[key];
         }
       });
 


### PR DESCRIPTION
The patch method is currently broken because `instance[key] == data[key];` doesn't assign the variable, it's returns a boolean and then does nothing else. It should be an assignment instead.