### PR TITLE
Remove method should allow a null id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,14 +166,14 @@ class Service {
   remove (id, params) {
     const {query, options} = utils.getQueryAndOptions(this.id, id, params, this.materialized_views);
 
-    return this.Model.findOneAsync(query, options).then(function (instance) {
-      if (!instance) {
-        throw new errors.NotFound(`No record found for id '${id}'`);
+    return this.Model.findAsync(query, options).then(function (instances) {
+      if (!instances.length) {
+        if(id) {
+          throw new errors.NotFound(`No record found for id '${id}'`);
+        }
+        throw new errors.NotFound(`No records match query`);
       }
-
-      return instance.deleteAsync().then(function () {
-        return {};
-      });
+      return Promise.all(instances.map(instance => instance.deleteAsync())).then(() => ({}));
     })
     .then(select(params, this.id))
     .catch(utils.errorHandler);

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,7 @@ export function getMaterializedOptions(options = {}, where, materialized_views) 
 export function getQueryAndOptions(idField, id, params, materialized_views) {
   let options = params.cassandra || {};
   let q = {};
-  if (id === null) {
+  if (id !== null) {
     q[idField] = id;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,7 @@ export function getMaterializedOptions(options = {}, where, materialized_views) 
 export function getQueryAndOptions(idField, id, params, materialized_views) {
   let options = params.cassandra || {};
   let q = {};
-  if (id == undefined) {
+  if (id === null) {
     q[idField] = id;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,9 @@ export function getMaterializedOptions(options = {}, where, materialized_views) 
 export function getQueryAndOptions(idField, id, params, materialized_views) {
   let options = params.cassandra || {};
   let q = {};
-  q[idField] = id;
+  if (id) {
+    q[idField] = id;
+  }
 
   if (params.query && Object.keys(params.query).length > 0) {
     const where = getWhere(params.query);

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,7 +72,7 @@ export function getMaterializedOptions(options = {}, where, materialized_views) 
 export function getQueryAndOptions(idField, id, params, materialized_views) {
   let options = params.cassandra || {};
   let q = {};
-  if (id) {
+  if (id == undefined) {
     q[idField] = id;
   }
 


### PR DESCRIPTION
Resolves https://github.com/asplogic/feathers-express-cassandra/issues/1

Per the docs, `null` is an acceptable id, and it means to run the query without an id parameter.  
https://docs.feathersjs.com/api/services.html#removeid-params